### PR TITLE
going metadataless without declaration in .filetree and implementing projectClass is incorrect

### DIFF
--- a/repository/.filetree
+++ b/repository/.filetree
@@ -1,4 +1,5 @@
 {
+	"MetaData" : false,
 	"noMethodMetaData" : true,
 	"separateMethodMetaAndSource" : false,
 	"useCypressPropertiesFile" : true }

--- a/repository/BaselineOfGrease.package/BaselineOfGrease.class/instance/projectClass.st
+++ b/repository/BaselineOfGrease.package/BaselineOfGrease.class/instance/projectClass.st
@@ -1,0 +1,4 @@
+accessing
+projectClass
+  Smalltalk at: #'MetacelloCypressBaselineProject' ifPresent: [ :cl | ^ cl ].
+  ^ super projectClass


### PR DESCRIPTION
declare that the filetree repository is metadata less and add projectClass to baseline so Metacello projects will load correctly