### PR TITLE
additional patch needed for 3.5.4 (messageText and comment method revert to pre 3.5.4 implementation

### DIFF
--- a/repository/BaselineOfGrease.package/BaselineOfGrease.class/instance/baselineGemStone..st
+++ b/repository/BaselineOfGrease.package/BaselineOfGrease.class/instance/baselineGemStone..st
@@ -90,7 +90,7 @@ baselineGemStone: spec
                 requires: #('Grease-GemStone-Core');
                 postLoadDoIt: #'initializeLatin1ToUtf8Encodings' ] ].
   spec
-    for: #(#'gs3.6.x')
+    for: #( #'gs3.5.4.x' #'gs3.5.5.x' #'gs3.6.x')
     do: [ 
       spec
         package: 'Grease-GemStone-Core'


### PR DESCRIPTION
patch is the same code that was needed for 3.6.0